### PR TITLE
Modernize the project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+Gemfile.lock
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in mcollective-test.gemspec
+gemspec
+
+gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,3 @@
-require 'rubygems'
-require 'rubygems/package_task'
-require 'rspec/core/rake_task'
+# frozen_string_literal: true
 
-spec = Gem::Specification.new do |s|
-  s.name = "mcollective-test"
-  s.version = "0.4.3"
-  s.author = "R.I.Pienaar"
-  s.email = "rip@devco.net"
-  s.homepage = "https://github.com/ripienaar/mcollective-test/"
-  s.summary = "Test helper for MCollective"
-  s.description = "Helpers, matchers and other utilities for writing agent, application and integration tests"
-  s.files = FileList["lib/**/*"].to_a
-  s.require_path = "lib"
-  s.has_rdoc = false
-end
-
-Gem::PackageTask.new(spec) do |pkg|
-  pkg.need_tar = true
-end
-
-task :default => :repackage
+require "bundler/gem_tasks"

--- a/mcollective-test.gemspec
+++ b/mcollective-test.gemspec
@@ -1,0 +1,13 @@
+spec = Gem::Specification.new do |s|
+  s.name = "mcollective-test"
+  s.version = "0.4.3"
+  s.author = "R.I.Pienaar"
+  s.email = "rip@devco.net"
+  s.homepage = "https://github.com/ripienaar/mcollective-test/"
+  s.summary = "Test helper for MCollective"
+  s.description = "Helpers, matchers and other utilities for writing agent, application and integration tests"
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  s.require_path = "lib"
+end


### PR DESCRIPTION
This add support for bundler with integration with rake to build /
release a gem, and allows development of dependencies with a local
version of the gem.

This is a prerequisite for having a testing nest for testing the
choria/mcollective tooling with Ruby 3.2 that ships with Puppet 8.
