### PR TITLE
Remove forgotten require

### DIFF
--- a/lib/mcollective/test/matchers.rb
+++ b/lib/mcollective/test/matchers.rb
@@ -2,7 +2,6 @@ module MCollective
   module Test
     module Matchers
       require 'mcollective/test/matchers/rpc_result_items.rb'
-      require 'mcollective/test/matchers/rpc_metadata.rb'
       require 'mcollective/test/matchers/rpc_status.rb'
       require 'mcollective/test/matchers/application_description.rb'
     end


### PR DESCRIPTION
In 06b841304ee9d33f8d6e1dad045004ef525d236b, this file was removed but
the require line was forgotten, leading to an exception when the code is
loaded.

Remove the now invalid `require`.
