### PR TITLE
Fix have_data_items

### DIFF
--- a/lib/mcollective/test/matchers/rpc_result_items.rb
+++ b/lib/mcollective/test/matchers/rpc_result_items.rb
@@ -1,5 +1,11 @@
 RSpec::Matchers.define(:have_data_items) do |expected|
   match do |actual|
-    actual.should include(data: include(expected))
+    if actual.is_a?(MCollective::RPC::Result)
+      actual.results.should include(expected)
+    elsif actual.is_a?(MCollective::Data::Result)
+      actual.instance_variable_get(:@data).should include(expected)
+    else
+      actual.should include(data: include(expected))
+    end
   end
 end


### PR DESCRIPTION
The matcher can be provided different types of objects that do not
behave the same way, so we really need to check what they are and act
differently based on this.
